### PR TITLE
scope Blockfrost project_ids per network + add slot datetime tooltips

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7926,6 +7926,30 @@ a.tcv-hash-truncate:hover {
   padding: 4px;
 }
 
+/* Slot tooltip — human-readable datetime for a chain slot */
+.tcv-slot-trigger {
+  cursor: help;
+  text-decoration: underline dotted rgba(148, 163, 184, 0.6);
+  text-underline-offset: 2px;
+}
+
+.tcv-slot-tooltip-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  white-space: nowrap;
+}
+
+.tcv-slot-tooltip-utc {
+  font-weight: 600;
+}
+
+.tcv-slot-tooltip-rel {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 11px;
+}
+
 /* Asset name tooltip with decoded string and hex */
 .tcv-asset-tooltip-content {
   display: flex;

--- a/src/components/ErrorDataFormatters.tsx
+++ b/src/components/ErrorDataFormatters.tsx
@@ -6,6 +6,7 @@ import { UtxoRef } from "./UtxoRef";
 import { AddressWithTooltip } from "./AddressWithTooltip";
 import { CopyIcon, CheckIcon, XCircleIcon } from "./Icons";
 import { AssetsTable, type AssetRow } from "./AssetsTable";
+import { SlotWithTooltip } from "./TransactionCardView/components/SlotWithTooltip";
 
 // ============================================================================
 // Type Definitions
@@ -656,11 +657,11 @@ export function SlotFormatter({ slot, currentSlot }: { slot: number; currentSlot
   
   return (
     <div className="error-formatter slot-formatter">
-      <span className="slot-value">{slot.toLocaleString()}</span>
+      <SlotWithTooltip slot={slot} className="slot-value" />
       <span className="slot-epoch">(epoch ~{epoch})</span>
       {currentSlot !== undefined && (
         <span className={`slot-diff ${slot > currentSlot ? "future" : "past"}`}>
-          {slot > currentSlot 
+          {slot > currentSlot
             ? `+${(slot - currentSlot).toLocaleString()} slots ahead`
             : `${(currentSlot - slot).toLocaleString()} slots ago`
           }

--- a/src/components/TransactionCardView/components/AuxiliaryDataSection.tsx
+++ b/src/components/TransactionCardView/components/AuxiliaryDataSection.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { CopyButton } from "./CopyButton";
 import { CollapsibleDataItem } from "./CollapsibleDataItem";
+import { SlotWithTooltip } from "./SlotWithTooltip";
 import type { AuxiliaryData, NativeScript } from "../types";
 
 interface AuxiliaryDataSectionProps {
@@ -81,17 +82,17 @@ function NativeScriptDisplay({ script, depth = 0 }: { script: NativeScript; dept
       <div className="tcv-native-script-item" style={{ marginLeft: indent }}>
         <span className="tcv-ns-icon">⏰</span>
         <span className="tcv-ns-type">Valid after</span>
-        <span className="tcv-ns-slot">slot {script.TimelockStart.slot}</span>
+        <span className="tcv-ns-slot">slot <SlotWithTooltip slot={script.TimelockStart.slot} /></span>
       </div>
     );
   }
-  
+
   if ("TimelockExpiry" in script) {
     return (
       <div className="tcv-native-script-item" style={{ marginLeft: indent }}>
         <span className="tcv-ns-icon">⏱️</span>
         <span className="tcv-ns-type">Valid before</span>
-        <span className="tcv-ns-slot">slot {script.TimelockExpiry.slot}</span>
+        <span className="tcv-ns-slot">slot <SlotWithTooltip slot={script.TimelockExpiry.slot} /></span>
       </div>
     );
   }

--- a/src/components/TransactionCardView/components/NativeScriptCard.tsx
+++ b/src/components/TransactionCardView/components/NativeScriptCard.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useEffect } from "react";
 import { CopyButton } from "./CopyButton";
 import { DiagnosticBadge } from "./DiagnosticBadge";
 import { HashWithTooltip } from "./HashWithTooltip";
+import { SlotWithTooltip } from "./SlotWithTooltip";
 import { getPathDiagnostics } from "../utils";
 import type { NativeScript, ValidationDiagnostic } from "../types";
 
@@ -17,7 +18,7 @@ interface NativeScriptCardProps {
   scriptHash?: string | null;
 }
 
-function getScriptType(script: NativeScript): { type: string; icon: string; description: string } {
+function getScriptType(script: NativeScript): { type: string; icon: string; description: React.ReactNode } {
   if ("ScriptPubkey" in script) {
     return { type: "ScriptPubkey", icon: "🔑", description: "Signature required" };
   }
@@ -31,10 +32,18 @@ function getScriptType(script: NativeScript): { type: string; icon: string; desc
     return { type: "ScriptNOfK", icon: "🔢", description: `${script.ScriptNOfK.n} of ${script.ScriptNOfK.native_scripts.length}` };
   }
   if ("TimelockStart" in script) {
-    return { type: "TimelockStart", icon: "⏰", description: `Valid after slot ${script.TimelockStart.slot}` };
+    return {
+      type: "TimelockStart",
+      icon: "⏰",
+      description: <>Valid after slot <SlotWithTooltip slot={script.TimelockStart.slot} /></>,
+    };
   }
   if ("TimelockExpiry" in script) {
-    return { type: "TimelockExpiry", icon: "⏱️", description: `Valid before slot ${script.TimelockExpiry.slot}` };
+    return {
+      type: "TimelockExpiry",
+      icon: "⏱️",
+      description: <>Valid before slot <SlotWithTooltip slot={script.TimelockExpiry.slot} /></>,
+    };
   }
   return { type: "Unknown", icon: "❓", description: "Unknown script type" };
 }
@@ -106,17 +115,17 @@ function NativeScriptDisplay({ script, depth = 0 }: { script: NativeScript; dept
       <div className="tcv-ns-item tcv-ns-timelock" style={{ marginLeft: indent }}>
         <span className="tcv-ns-item-icon">⏰</span>
         <span className="tcv-ns-timelock-label">Valid after</span>
-        <span className="tcv-ns-slot">{script.TimelockStart.slot}</span>
+        <SlotWithTooltip slot={script.TimelockStart.slot} className="tcv-ns-slot" />
       </div>
     );
   }
-  
+
   if ("TimelockExpiry" in script) {
     return (
       <div className="tcv-ns-item tcv-ns-timelock" style={{ marginLeft: indent }}>
         <span className="tcv-ns-item-icon">⏱️</span>
         <span className="tcv-ns-timelock-label">Valid before</span>
-        <span className="tcv-ns-slot">{script.TimelockExpiry.slot}</span>
+        <SlotWithTooltip slot={script.TimelockExpiry.slot} className="tcv-ns-slot" />
       </div>
     );
   }

--- a/src/components/TransactionCardView/components/SlotWithTooltip.tsx
+++ b/src/components/TransactionCardView/components/SlotWithTooltip.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React from "react";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { useTransactionValidator } from "@/context/TransactionValidatorContext";
+import { formatSlotDate, formatSlotRelative } from "@/utils/slotTime";
+
+interface SlotWithTooltipProps {
+  slot: number | bigint | string;
+  className?: string;
+  /** Render the slot number with locale grouping (default true). */
+  localeFormat?: boolean;
+}
+
+export function SlotWithTooltip({ slot, className = "", localeFormat = true }: SlotWithTooltipProps) {
+  const { network } = useTransactionValidator();
+  const slotNum = typeof slot === "string" ? Number(slot) : slot;
+  const display = localeFormat ? Number(slotNum).toLocaleString() : String(slot);
+  const utc = formatSlotDate(slotNum, network);
+  const rel = formatSlotRelative(slotNum, network);
+
+  return (
+    <Tooltip.Provider delayDuration={200}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <span className={`tcv-slot-trigger ${className}`}>{display}</span>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className="tcv-hash-tooltip" sideOffset={5} side="top">
+            <div className="tcv-slot-tooltip-content">
+              <div className="tcv-slot-tooltip-utc">{utc}</div>
+              <div className="tcv-slot-tooltip-rel">{rel}</div>
+            </div>
+            <Tooltip.Arrow className="tcv-tooltip-arrow" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}

--- a/src/components/TransactionCardView/components/SundaeOrderPanel.tsx
+++ b/src/components/TransactionCardView/components/SundaeOrderPanel.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { CopyButton } from "./CopyButton";
 import { HashWithTooltip } from "./HashWithTooltip";
+import { SlotWithTooltip } from "./SlotWithTooltip";
 import { formatAda, formatAssetName, truncateHash } from "../utils";
 import {
   loadPool,
@@ -258,9 +259,9 @@ function describeOwner(owner: V3Multisig): React.ReactNode {
         </span>
       );
     case "Before":
-      return <span>Before slot {owner.time.toString()}</span>;
+      return <span>Before slot <SlotWithTooltip slot={owner.time.toString()} /></span>;
     case "After":
-      return <span>After slot {owner.time.toString()}</span>;
+      return <span>After slot <SlotWithTooltip slot={owner.time.toString()} /></span>;
   }
 }
 
@@ -746,7 +747,7 @@ function PoolBody({ datum }: { datum: SundaePoolDatum }) {
         )}
         <div className="tcv-sundae-row">
           <span className="tcv-sundae-leg-label">Market opens</span>
-          <span className="tcv-sundae-mono">slot {datum.marketOpenSlot.toString()}</span>
+          <span className="tcv-sundae-mono">slot <SlotWithTooltip slot={datum.marketOpenSlot.toString()} /></span>
         </div>
       </div>
     </>

--- a/src/components/TransactionCardView/components/TransactionDetailsSection.tsx
+++ b/src/components/TransactionCardView/components/TransactionDetailsSection.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useEffect } from "react";
 import { DiagnosticBadge } from "./DiagnosticBadge";
 import { CopyButton } from "./CopyButton";
 import { HashWithTooltip } from "./HashWithTooltip";
+import { SlotWithTooltip } from "./SlotWithTooltip";
 import { getPathDiagnostics } from "../utils";
 import type { TransactionBody, ValidationDiagnostic } from "../types";
 
@@ -81,7 +82,7 @@ function DetailField({
       displayValue = <span className="tcv-detail-ada">₳ {formatAda(String(value))}</span>;
       break;
     case "slot":
-      displayValue = <span className="tcv-detail-slot">{Number(value).toLocaleString()}</span>;
+      displayValue = <SlotWithTooltip slot={Number(value)} className="tcv-detail-slot" />;
       break;
     case "number":
       displayValue = <span className="tcv-detail-number">{Number(value).toLocaleString()}</span>;

--- a/src/components/TransactionCardView/components/index.ts
+++ b/src/components/TransactionCardView/components/index.ts
@@ -15,6 +15,7 @@ export { CollapsibleDataItem } from "./CollapsibleDataItem";
 export { TransactionDetailsSection } from "./TransactionDetailsSection";
 export { RequiredSignersCard } from "./RequiredSignersCard";
 export { HashWithTooltip } from "./HashWithTooltip";
+export { SlotWithTooltip } from "./SlotWithTooltip";
 export { VotingProcedureCard } from "./VotingProcedureCard";
 export { VotingProposalCard } from "./VotingProposalCard";
 export { PlutusScriptCard } from "./PlutusScriptCard";

--- a/src/context/TransactionValidatorContext.tsx
+++ b/src/context/TransactionValidatorContext.tsx
@@ -14,9 +14,40 @@ import type { TransactionData } from "@/components/TransactionCardView/types";
 import type { KoiosUtxoInfo } from "@/utils/koiosTypes";
 import { parseHash, parseValidatorShare } from "@/utils/shareLink";
 
+// Blockfrost project_ids are strictly tied to a single network, so they are
+// stored per-network. Koios tokens are valid across networks per koios.rest's
+// pricing page ("API Tokens are valid across networks"), so a single key is
+// stored. The legacy un-suffixed Blockfrost key (pre 2026-05) is migrated
+// into the mainnet slot on first read so users don't lose their entry.
 const KOIOS_API_KEY_STORAGE_KEY = "cquisitor_koios_api_key";
-const BLOCKFROST_API_KEY_STORAGE_KEY = "cquisitor_blockfrost_api_key";
+const BLOCKFROST_API_KEY_STORAGE_PREFIX = "cquisitor_blockfrost_api_key";
 const PROVIDER_STORAGE_KEY = "cquisitor_data_provider";
+
+const NETWORKS: ReadonlyArray<NetworkType> = ["mainnet", "preview", "preprod"];
+
+type BlockfrostKeyMap = Record<NetworkType, string>;
+
+function blockfrostStorageKey(network: NetworkType): string {
+  return `${BLOCKFROST_API_KEY_STORAGE_PREFIX}_${network}`;
+}
+
+function loadBlockfrostKeys(): BlockfrostKeyMap {
+  const empty: BlockfrostKeyMap = { mainnet: "", preview: "", preprod: "" };
+  if (typeof window === "undefined") return empty;
+  const map = { ...empty };
+  for (const net of NETWORKS) {
+    map[net] = localStorage.getItem(blockfrostStorageKey(net)) || "";
+  }
+  const legacy = localStorage.getItem(BLOCKFROST_API_KEY_STORAGE_PREFIX);
+  if (legacy) {
+    if (!map.mainnet) {
+      map.mainnet = legacy;
+      localStorage.setItem(blockfrostStorageKey("mainnet"), legacy);
+    }
+    localStorage.removeItem(BLOCKFROST_API_KEY_STORAGE_PREFIX);
+  }
+  return map;
+}
 
 export interface DecodedTransaction {
   transaction_hash?: string;
@@ -117,21 +148,21 @@ export function TransactionValidatorProvider({ children }: { children: ReactNode
     const v = localStorage.getItem(PROVIDER_STORAGE_KEY);
     return v === "blockfrost" ? "blockfrost" : "koios";
   });
-  const [koiosKey, setKoiosKey] = useState(() => {
+  const [koiosKey, setKoiosKey] = useState<string>(() => {
     if (typeof window === "undefined") return "";
     return localStorage.getItem(KOIOS_API_KEY_STORAGE_KEY) || "";
   });
-  const [blockfrostKey, setBlockfrostKey] = useState(() => {
-    if (typeof window === "undefined") return "";
-    return localStorage.getItem(BLOCKFROST_API_KEY_STORAGE_KEY) || "";
-  });
-  const apiKey = provider === "blockfrost" ? blockfrostKey : koiosKey;
+  const [blockfrostKeys, setBlockfrostKeys] = useState<BlockfrostKeyMap>(() => loadBlockfrostKeys());
+  const apiKey = provider === "blockfrost" ? blockfrostKeys[network] : koiosKey;
   const setApiKey = useCallback(
     (value: string) => {
-      if (provider === "blockfrost") setBlockfrostKey(value);
-      else setKoiosKey(value);
+      if (provider === "blockfrost") {
+        setBlockfrostKeys((prev) => ({ ...prev, [network]: value }));
+      } else {
+        setKoiosKey(value);
+      }
     },
-    [provider]
+    [provider, network]
   );
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState<ValidationResult | null>(null);
@@ -149,21 +180,25 @@ export function TransactionValidatorProvider({ children }: { children: ReactNode
   const [ctxIncompatibleWarning, setCtxIncompatibleWarning] = useState(false);
   const [futureVersionWarning, setFutureVersionWarning] = useState(false);
 
-  // Save API key (for the currently active provider) to localStorage.
+  // Save the API key for the currently active provider. Blockfrost is scoped
+  // by network; Koios is a single shared key.
   const handleApiKeyChange = useCallback(
     (value: string) => {
       const trimmed = value.trim();
       const storageKey =
-        provider === "blockfrost" ? BLOCKFROST_API_KEY_STORAGE_KEY : KOIOS_API_KEY_STORAGE_KEY;
-      if (provider === "blockfrost") setBlockfrostKey(value);
-      else setKoiosKey(value);
+        provider === "blockfrost" ? blockfrostStorageKey(network) : KOIOS_API_KEY_STORAGE_KEY;
+      if (provider === "blockfrost") {
+        setBlockfrostKeys((prev) => ({ ...prev, [network]: value }));
+      } else {
+        setKoiosKey(value);
+      }
       if (trimmed) {
         localStorage.setItem(storageKey, trimmed);
       } else {
         localStorage.removeItem(storageKey);
       }
     },
-    [provider]
+    [provider, network]
   );
 
   const setProvider = useCallback((value: DataProvider) => {

--- a/src/utils/slotTime.ts
+++ b/src/utils/slotTime.ts
@@ -1,0 +1,40 @@
+import type { NetworkType } from "@cardananium/cquisitor-lib";
+
+// Post-Shelley anchors: (zero-slot, zero-time in seconds since epoch).
+// One slot = 1 second post-Shelley. Pre-Shelley/Byron slots are not handled
+// here — they predate any timelock/TTL field users will see.
+//
+// Mainnet:  Shelley start at slot 4_492_800, 2020-07-29 21:44:51 UTC
+// Preprod:  Shelley start at slot 86_400,   2022-06-21 00:00:00 UTC
+// Preview:  no Byron era,                    2022-10-25 00:00:00 UTC
+const ANCHORS: Record<NetworkType, { zeroSlot: number; zeroTimeSec: number }> = {
+  mainnet: { zeroSlot: 4_492_800, zeroTimeSec: 1_596_059_091 },
+  preprod: { zeroSlot: 86_400, zeroTimeSec: 1_655_769_600 },
+  preview: { zeroSlot: 0, zeroTimeSec: 1_666_656_000 },
+};
+
+export function slotToDate(slot: number | bigint, network: NetworkType): Date {
+  const slotNum = typeof slot === "bigint" ? Number(slot) : slot;
+  const { zeroSlot, zeroTimeSec } = ANCHORS[network];
+  return new Date((zeroTimeSec + (slotNum - zeroSlot)) * 1000);
+}
+
+export function formatSlotDate(slot: number | bigint, network: NetworkType): string {
+  const d = slotToDate(slot, network);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`;
+}
+
+export function formatSlotRelative(slot: number | bigint, network: NetworkType, now: Date = new Date()): string {
+  const target = slotToDate(slot, network).getTime();
+  const diffSec = Math.round((target - now.getTime()) / 1000);
+  const abs = Math.abs(diffSec);
+  const future = diffSec >= 0;
+  const fmt = (n: number, unit: string) => `${n} ${unit}${n === 1 ? "" : "s"} ${future ? "from now" : "ago"}`;
+  if (abs < 60) return fmt(abs, "second");
+  if (abs < 3600) return fmt(Math.round(abs / 60), "minute");
+  if (abs < 86400) return fmt(Math.round(abs / 3600), "hour");
+  if (abs < 86400 * 30) return fmt(Math.round(abs / 86400), "day");
+  if (abs < 86400 * 365) return fmt(Math.round(abs / (86400 * 30)), "month");
+  return fmt(Math.round(abs / (86400 * 365)), "year");
+}


### PR DESCRIPTION
Blockfrost project_ids are tied to a specific network, so storing one global key caused mainnet/preview/preprod to fight over the same slot. Store Blockfrost keys per network and migrate the legacy un-suffixed key into the mainnet slot. Koios tokens remain a single shared key — koios.rest's pricing page explicitly states "API Tokens are valid across networks."

Also Adds a SlotWithTooltip component (Radix tooltip showing UTC datetime + relative time) backed by a small slotTime helper with mainnet, preprod, and preview anchors. Wired into transaction body TTL/validity, native script timelocks (header + inner), aux-data timelocks, Sundae V3 order Before/After multisig constraints, the market open slot, and SlotFormatter.

<img width="798" height="212" alt="image" src="https://github.com/user-attachments/assets/4c389fd7-4ee1-4709-bcc7-49e3fbd5f42b" />
