### PR TITLE
strip whitespace from pasted hex/base64 input across all parsers

### DIFF
--- a/src/app/TransactionValidatorContent.tsx
+++ b/src/app/TransactionValidatorContent.tsx
@@ -37,6 +37,7 @@ import { decode_specific_type, extract_hashes_from_transaction_js } from "@carda
 import type { ExtractedHashes } from "@cardananium/cquisitor-lib";
 import { convertSerdeNumbers } from "@/utils/serdeNumbers";
 import { reorderTransactionFields } from "@/utils/reorderTransactionFields";
+import { normalizeHexOrBase64 } from "@/utils/inputNormalization";
 import {
   useTransactionValidator,
   type DecodedTransaction,
@@ -56,34 +57,6 @@ import type {
 const VIEW_MODE_STORAGE_KEY = "cquisitor_tx_validator_view_mode";
 const VIEW_MODE_SELECTED_KEY = "cquisitor_tx_validator_view_mode_selected";
 
-// Check if string is valid hex
-function isValidHex(str: string): boolean {
-  const trimmed = str.trim();
-  if (trimmed.length === 0) return false;
-  return /^[0-9a-fA-F]+$/.test(trimmed);
-}
-
-// Check if string is valid base64
-function isValidBase64(str: string): boolean {
-  const trimmed = str.trim();
-  if (trimmed.length === 0) return false;
-  // Check base64 format: alphanumeric, +, /, and optional padding =
-  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(trimmed)) return false;
-  if (trimmed.length % 4 !== 0) return false;
-  try {
-    const decoded = Buffer.from(trimmed, "base64");
-    // Verify it's actually valid by re-encoding
-    return decoded.length > 0 && Buffer.from(decoded).toString("base64") === trimmed;
-  } catch {
-    return false;
-  }
-}
-
-// Convert base64 to hex
-function base64ToHex(base64: string): string {
-  return Buffer.from(base64.trim(), "base64").toString("hex");
-}
-
 function formatRelativeAge(epochMs: number): string {
   const diff = Math.max(0, Date.now() - epochMs);
   const s = Math.floor(diff / 1000);
@@ -96,23 +69,7 @@ function formatRelativeAge(epochMs: number): string {
   return `${d}d ago`;
 }
 
-// Process input: convert base64 to hex if needed
-function processTransactionInput(input: string): { hex: string; wasBase64: boolean } {
-  const trimmed = input.trim();
-  
-  // If it's already valid hex, return as is
-  if (isValidHex(trimmed)) {
-    return { hex: trimmed, wasBase64: false };
-  }
-  
-  // Try to convert from base64
-  if (isValidBase64(trimmed)) {
-    return { hex: base64ToHex(trimmed), wasBase64: true };
-  }
-  
-  // Return as-is (will fail validation with proper error)
-  return { hex: trimmed, wasBase64: false };
-}
+const processTransactionInput = normalizeHexOrBase64;
 
 type DiagnosticSeverity = "error" | "warning" | "info" | "success";
 

--- a/src/app/cardano-cbor/CardanoCborContent.tsx
+++ b/src/app/cardano-cbor/CardanoCborContent.tsx
@@ -25,30 +25,11 @@ import {
   buildValidatorUrl,
   openExternalUrl,
 } from "@/utils/externalApps";
+import { isValidBase64, base64ToHex, stripWhitespace } from "@/utils/inputNormalization";
 
 // Types that require DecodingParams
 const TYPES_WITH_PLUTUS_SCRIPT_VERSION = ["PlutusScript"];
 const TYPES_WITH_PLUTUS_DATA_SCHEMA = ["PlutusData"];
-
-// Check if string is valid base64
-function isValidBase64(str: string): boolean {
-  const trimmed = str.trim();
-  if (trimmed.length === 0) return false;
-  // Check base64 format: alphanumeric, +, /, and optional padding =
-  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(trimmed)) return false;
-  if (trimmed.length % 4 !== 0) return false;
-  try {
-    const decoded = Buffer.from(trimmed, "base64");
-    // Verify it's actually valid by re-encoding
-    return decoded.length > 0 && Buffer.from(decoded).toString("base64") === trimmed;
-  } catch {
-    return false;
-  }
-}
-
-function base64ToHex(base64: string): string {
-  return Buffer.from(base64.trim(), "base64").toString("hex");
-}
 
 // Result of trying to detect types
 interface DetectionResult {
@@ -77,28 +58,28 @@ function filterTypes(types: string[]): string[] {
 
 // Try to detect types for input, with fallback to base64 conversion
 function detectTypesWithFallback(rawInput: string): DetectionResult {
-  const trimmed = rawInput.trim();
-  
-  // First, try the original input directly
+  const normalized = stripWhitespace(rawInput);
+
+  // First, try the normalized input directly
   // This handles: hex, bech32, base58, and potentially base64 if decoder supports it
   try {
-    const rawTypes = get_possible_types_for_input(trimmed);
+    const rawTypes = get_possible_types_for_input(normalized);
     const types = filterTypes(rawTypes);
     if (types.length > 0) {
       return {
         types,
-        processedInput: trimmed,
+        processedInput: normalized,
         notification: null,
       };
     }
   } catch {
     // Continue to fallback
   }
-  
+
   // If original input didn't work and it could be base64, try converting to hex
-  if (isValidBase64(trimmed)) {
+  if (isValidBase64(normalized)) {
     try {
-      const hexFromBase64 = base64ToHex(trimmed);
+      const hexFromBase64 = base64ToHex(normalized);
       const rawTypes = get_possible_types_for_input(hexFromBase64);
       const types = filterTypes(rawTypes);
       if (types.length > 0) {
@@ -112,11 +93,11 @@ function detectTypesWithFallback(rawInput: string): DetectionResult {
       // Base64 conversion failed
     }
   }
-  
+
   // Nothing worked
   return {
     types: [],
-    processedInput: trimmed,
+    processedInput: normalized,
     notification: null,
   };
 }

--- a/src/app/general-cbor/GeneralCborContent.tsx
+++ b/src/app/general-cbor/GeneralCborContent.tsx
@@ -13,29 +13,22 @@ import EmptyStatePlaceholder from "@/components/EmptyStatePlaceholder";
 import ShareButton from "@/components/ShareButton";
 import { convertSerdeNumbers } from "@/utils/serdeNumbers";
 import { cborErrorToLocation } from "@/utils/cborError";
+import { base64ToHex, stripWhitespace } from "@/utils/inputNormalization";
 
-function isValidBase64(str: string): boolean {
+// Heuristic base64 check that intentionally rejects pure-hex input so we don't
+// mis-route hex through a base64 decode. Caller must pass whitespace-stripped
+// input. Differs from the strict isValidBase64 in inputNormalization, which
+// considers plain hex (e.g. "deadbeef") a valid base64 string.
+function looksLikeBase64(input: string): boolean {
+  if (input.length === 0) return false;
+  if (!/^[A-Za-z0-9+/]+=*$/.test(input)) return false;
+  if (!/[g-zG-Z+/=]/.test(input)) return false;
   try {
-    const trimmed = str.trim();
-    if (trimmed.length === 0) return false;
-    // Check if it looks like base64 (contains non-hex chars that are valid base64)
-    if (/^[A-Za-z0-9+/]+=*$/.test(trimmed) && /[g-zG-Z+/=]/i.test(trimmed)) {
-      atob(trimmed);
-      return true;
-    }
-    return false;
+    atob(input);
+    return true;
   } catch {
     return false;
   }
-}
-
-function base64ToHex(base64: string): string {
-  const binary = atob(base64.trim());
-  let hex = "";
-  for (let i = 0; i < binary.length; i++) {
-    hex += binary.charCodeAt(i).toString(16).padStart(2, "0");
-  }
-  return hex;
 }
 
 export default function GeneralCborContent() {
@@ -73,8 +66,11 @@ export default function GeneralCborContent() {
 
     // Debounce decode to avoid cursor jumping
     debounceRef.current = setTimeout(() => {
+      // Strip whitespace upfront so wrapped/column-formatted pastes parse correctly.
+      let hex = stripWhitespace(input);
+
       // Clear if empty
-      if (!input.trim()) {
+      if (hex.length === 0) {
         setHexValue("");
         setDecodedJson(null);
         setError(null);
@@ -83,18 +79,15 @@ export default function GeneralCborContent() {
         return;
       }
 
-      let hex = input.trim();
-
       // Check if it's base64
-      if (isValidBase64(hex)) {
+      if (looksLikeBase64(hex)) {
         hex = base64ToHex(hex);
         setNotification("Base64 → hex");
       } else {
         setNotification(null);
       }
 
-      // Clean up hex (whitespace-only, preserve everything else for the lib to diagnose)
-      hex = hex.replace(/\s/g, "").toLowerCase();
+      hex = hex.toLowerCase();
 
       // Decode CBOR — the new API never throws; errors come as { ok: false, ... }.
       const raw = cbor_to_json(hex) as CborDecodeResult;

--- a/src/utils/inputNormalization.ts
+++ b/src/utils/inputNormalization.ts
@@ -1,0 +1,41 @@
+// Helpers for normalizing pasted hex / base64 blobs. Pastes commonly arrive
+// wrapped across multiple lines (column-formatted dumps, trailing carriage
+// returns, PEM-style 64-char-per-line base64). Neither encoding includes
+// meaningful internal whitespace, so we strip it before validating.
+
+export function stripWhitespace(input: string): string {
+  return input.replace(/\s+/g, "");
+}
+
+// Caller should pass whitespace-stripped input.
+export function isValidHex(input: string): boolean {
+  if (input.length === 0) return false;
+  return /^[0-9a-fA-F]+$/.test(input);
+}
+
+// Strict base64 check: format, length-mod-4, and round-trip equality.
+// Caller should pass whitespace-stripped input.
+export function isValidBase64(input: string): boolean {
+  if (input.length === 0) return false;
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(input)) return false;
+  if (input.length % 4 !== 0) return false;
+  try {
+    const decoded = Buffer.from(input, "base64");
+    return decoded.length > 0 && Buffer.from(decoded).toString("base64") === input;
+  } catch {
+    return false;
+  }
+}
+
+export function base64ToHex(input: string): string {
+  return Buffer.from(input, "base64").toString("hex");
+}
+
+// Normalize a pasted hex/base64 blob into hex. Unrecognized input is
+// returned stripped so the downstream parser produces a sensible error.
+export function normalizeHexOrBase64(input: string): { hex: string; wasBase64: boolean } {
+  const normalized = stripWhitespace(input);
+  if (isValidHex(normalized)) return { hex: normalized, wasBase64: false };
+  if (isValidBase64(normalized)) return { hex: base64ToHex(normalized), wasBase64: true };
+  return { hex: normalized, wasBase64: false };
+}


### PR DESCRIPTION
Pastes commonly arrive wrapped across multiple lines (column-formatted dumps, trailing carriage returns, PEM-style 64-char-per-line base64). The validator and CBOR pages previously only edge-trimmed, so internal whitespace slipped past the hex regex and produced confusing parse errors.

Extract the hex/base64 helpers into src/utils/inputNormalization and strip whitespace upfront in all three input flows. GeneralCborContent keeps its own heuristic base64 detector (which intentionally rejects pure-hex input) but shares base64ToHex and stripWhitespace.