### PR TITLE
Tx budget summary + Plutus script context display

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "cquisitor",
       "dependencies": {
-        "@cardananium/cquisitor-lib": "^0.1.0-beta.55",
+        "@cardananium/cquisitor-lib": "^0.1.0-beta.56",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.6",
@@ -40,6 +40,9 @@
         "typescript": "^5",
       },
     },
+  },
+  "overrides": {
+    "postcss": "^8.5.10",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -78,7 +81,7 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@cardananium/cquisitor-lib": ["@cardananium/cquisitor-lib@0.1.0-beta.55", "", {}, "sha512-aR3Bv/FLKbasrjlYn2bNZHTzt+m75/uPcvbPFz8J3oNSabJcBzgeiYggHanvnMTm6+mpcM3VRD+kdc4Dd3ufLQ=="],
+    "@cardananium/cquisitor-lib": ["@cardananium/cquisitor-lib@0.1.0-beta.56", "", {}, "sha512-+dwCcmknJiOX4LMDysX/JlrP7m6EWTJX1kibBoF155qFFlgbUUYZEsWgwV0old7Kry4p9HWa0gFQRmVVMGQ0kQ=="],
 
     "@cbor-extract/cbor-extract-darwin-arm64": ["@cbor-extract/cbor-extract-darwin-arm64@2.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w=="],
 
@@ -912,7 +915,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1119,8 +1122,6 @@
     "is-bun-module/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@cardananium/cquisitor-lib": "^0.1.0-beta.55",
+    "@cardananium/cquisitor-lib": "^0.1.0-beta.56",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.6",

--- a/src/app/TransactionValidatorContent.tsx
+++ b/src/app/TransactionValidatorContent.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ResizablePanels from "@/components/ResizablePanels";
 import ValidationJsonViewer, { type ValidationDiagnostic } from "@/components/ValidationJsonViewer";
+import JsonViewer from "@/components/JsonViewer";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import * as Tabs from "@radix-ui/react-tabs";
 import * as Accordion from "@radix-ui/react-accordion";
@@ -442,16 +443,50 @@ function ExUnitProgress({
   );
 }
 
-function ScriptContextSection({ bytes }: { bytes: string }) {
+type ScriptContextView = "json" | "hex";
+
+function ScriptContextSection({
+  bytes,
+  json,
+}: {
+  bytes: string | null | undefined;
+  json: string | null | undefined;
+}) {
+  // Parse once. If parsing fails (shouldn't, but be defensive), fall back to
+  // treating the JSON view as unavailable and showing only hex.
+  const parsedJson = useMemo(() => {
+    if (!json) return null;
+    try {
+      return JSON.parse(json) as unknown;
+    } catch {
+      return null;
+    }
+  }, [json]);
+
+  const hasJson = parsedJson !== null;
+  const hasHex = !!bytes;
+  const [view, setView] = useState<ScriptContextView>(hasJson ? "json" : "hex");
   const [copied, setCopied] = useState(false);
-  const byteCount = Math.floor(bytes.length / 2);
+
+  if (!hasJson && !hasHex) return null;
+
+  const byteCount = hasHex ? Math.floor(bytes!.length / 2) : null;
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
-    navigator.clipboard.writeText(bytes);
+    const text = view === "json" && hasJson
+      ? JSON.stringify(parsedJson, null, 2)
+      : (bytes ?? "");
+    navigator.clipboard.writeText(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const switchView = (next: ScriptContextView) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setView(next);
   };
 
   return (
@@ -460,21 +495,51 @@ function ScriptContextSection({ bytes }: { bytes: string }) {
         <Collapsible.Trigger className="plutus-script-context-trigger">
           <ChevronDownIcon size={12} className="plutus-script-context-chevron" />
           <span className="plutus-ex-label">Script Context</span>
-          <span className="plutus-script-context-size">({byteCount.toLocaleString()} bytes)</span>
+          {byteCount !== null && (
+            <span className="plutus-script-context-size">({byteCount.toLocaleString()} bytes)</span>
+          )}
         </Collapsible.Trigger>
+        {hasJson && hasHex && (
+          <div className="plutus-script-context-toggle" role="tablist">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === "json"}
+              className={`plutus-script-context-toggle-btn ${view === "json" ? "active" : ""}`}
+              onClick={switchView("json")}
+            >
+              JSON
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === "hex"}
+              className={`plutus-script-context-toggle-btn ${view === "hex" ? "active" : ""}`}
+              onClick={switchView("hex")}
+            >
+              Hex
+            </button>
+          </div>
+        )}
         <span
           role="button"
           tabIndex={0}
           className={`plutus-script-context-copy ${copied ? "copied" : ""}`}
           onClick={handleCopy}
           onKeyDown={(e) => e.key === "Enter" && handleCopy(e as unknown as React.MouseEvent)}
-          title={copied ? "Copied!" : "Copy hex"}
+          title={copied ? "Copied!" : view === "json" ? "Copy JSON" : "Copy hex"}
         >
           {copied ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
         </span>
       </div>
       <Collapsible.Content>
-        <div className="plutus-script-context-body">{bytes}</div>
+        {view === "json" && hasJson ? (
+          <div className="plutus-script-context-body plutus-script-context-body-json">
+            <JsonViewer data={parsedJson} expanded={2} />
+          </div>
+        ) : (
+          <div className="plutus-script-context-body">{bytes}</div>
+        )}
       </Collapsible.Content>
     </Collapsible.Root>
   );
@@ -577,8 +642,11 @@ function PlutusScriptResults({ results }: { results: EvalRedeemerResult[] }) {
                     </div>
                   </div>
                 )}
-                {result.script_context_bytes && (
-                  <ScriptContextSection bytes={result.script_context_bytes} />
+                {(result.script_context_bytes || result.script_context) && (
+                  <ScriptContextSection
+                    bytes={result.script_context_bytes}
+                    json={result.script_context}
+                  />
                 )}
               </div>
             </Accordion.Content>

--- a/src/app/TransactionValidatorContent.tsx
+++ b/src/app/TransactionValidatorContent.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ResizablePanels from "@/components/ResizablePanels";
 import ValidationJsonViewer, { type ValidationDiagnostic } from "@/components/ValidationJsonViewer";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import * as Tabs from "@radix-ui/react-tabs";
 import * as Accordion from "@radix-ui/react-accordion";
+import * as Collapsible from "@radix-ui/react-collapsible";
 import * as Progress from "@radix-ui/react-progress";
 import Select from "@/components/Select";
 import {
@@ -441,6 +442,44 @@ function ExUnitProgress({
   );
 }
 
+function ScriptContextSection({ bytes }: { bytes: string }) {
+  const [copied, setCopied] = useState(false);
+  const byteCount = Math.floor(bytes.length / 2);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    navigator.clipboard.writeText(bytes);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Collapsible.Root className="plutus-script-context">
+      <div className="plutus-script-context-header">
+        <Collapsible.Trigger className="plutus-script-context-trigger">
+          <ChevronDownIcon size={12} className="plutus-script-context-chevron" />
+          <span className="plutus-ex-label">Script Context</span>
+          <span className="plutus-script-context-size">({byteCount.toLocaleString()} bytes)</span>
+        </Collapsible.Trigger>
+        <span
+          role="button"
+          tabIndex={0}
+          className={`plutus-script-context-copy ${copied ? "copied" : ""}`}
+          onClick={handleCopy}
+          onKeyDown={(e) => e.key === "Enter" && handleCopy(e as unknown as React.MouseEvent)}
+          title={copied ? "Copied!" : "Copy hex"}
+        >
+          {copied ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+        </span>
+      </div>
+      <Collapsible.Content>
+        <div className="plutus-script-context-body">{bytes}</div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}
+
 // Plutus Script Results component with Accordion
 function PlutusScriptResults({ results }: { results: EvalRedeemerResult[] }) {
   if (results.length === 0) {
@@ -538,6 +577,9 @@ function PlutusScriptResults({ results }: { results: EvalRedeemerResult[] }) {
                     </div>
                   </div>
                 )}
+                {result.script_context_bytes && (
+                  <ScriptContextSection bytes={result.script_context_bytes} />
+                )}
               </div>
             </Accordion.Content>
           </Accordion.Item>
@@ -592,6 +634,34 @@ export default function TransactionValidatorContent() {
   
   const focusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [copiedDiagnostics, setCopiedDiagnostics] = useState(false);
+
+  // Raw CBOR hex of the current input, used by the card view to show tx size.
+  // Memoized so we don't re-scan a large base64 blob on every parent render.
+  const txCborHex = useMemo(() => {
+    const trimmed = txInput.trim();
+    if (!trimmed) return null;
+    return processTransactionInput(txInput).hex;
+  }, [txInput]);
+
+  // Actual (calculated) tx-wide ex units, summed from successful script evals.
+  // Failed evals don't contribute a meaningful calculated_ex_units, so we skip
+  // them rather than zero them — the failure surfaces elsewhere in the UI.
+  const actualExUnits = useMemo(() => {
+    const evals = result?.eval_redeemer_results;
+    if (!evals || evals.length === 0) return null;
+    let mem = BigInt(0);
+    let steps = BigInt(0);
+    let any = false;
+    for (const r of evals) {
+      if (!r.success) continue;
+      try {
+        mem += BigInt(r.calculated_ex_units.mem);
+        steps += BigInt(r.calculated_ex_units.steps);
+        any = true;
+      } catch { /* ignore malformed */ }
+    }
+    return any ? { mem, steps } : null;
+  }, [result]);
   
   // View mode state - load from localStorage if available
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
@@ -1335,6 +1405,16 @@ export default function TransactionValidatorContent() {
             focusedPath={focusedPath}
             extractedHashes={extractedHashes}
             inputUtxoInfoMap={inputUtxoInfoMap}
+            txCborHex={txCborHex}
+            protocolMaxes={
+              fetchedContext
+                ? {
+                    maxTxSize: fetchedContext.protocolParameters.maxTransactionSize,
+                    maxTxExUnits: fetchedContext.protocolParameters.maxTxExecutionUnits,
+                  }
+                : null
+            }
+            actualExUnits={actualExUnits}
           />
         ) : (
           <ValidationJsonViewer 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4144,6 +4144,82 @@ input, textarea, select, button {
   margin-top: 2px;
 }
 
+.plutus-script-context {
+  margin-top: 8px;
+}
+
+.plutus-script-context-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.plutus-script-context-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.plutus-script-context-chevron {
+  color: #94a3b8;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+  transform: rotate(-90deg);
+}
+
+.plutus-script-context-trigger[data-state="open"] .plutus-script-context-chevron {
+  transform: rotate(0deg);
+}
+
+.plutus-script-context-size {
+  font-size: 11px;
+  color: #94a3b8;
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.plutus-script-context-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 4px;
+  margin-left: auto;
+  color: #94a3b8;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.plutus-script-context-copy:hover {
+  color: #475569;
+  background: #e2e8f0;
+}
+
+.plutus-script-context-copy.copied {
+  color: #16a34a;
+}
+
+.plutus-script-context-body {
+  padding: 10px 12px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  font-size: 11px;
+  color: #334155;
+  font-family: 'IBM Plex Mono', monospace;
+  line-height: 1.5;
+  max-height: 240px;
+  overflow-y: auto;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+}
+
 .plutus-empty-state {
   flex: 1;
   display: flex;
@@ -6385,6 +6461,42 @@ input, textarea, select, button {
 .tcv-summary-stat {
   font-size: 11px;
   color: #64748b;
+}
+
+.tcv-summary-budget {
+  font-variant-numeric: tabular-nums;
+}
+
+.tcv-summary-budget-label {
+  font-weight: 600;
+  color: #475569;
+}
+
+.tcv-summary-budget-pct {
+  color: #94a3b8;
+}
+
+.tcv-summary-budget.over-budget {
+  color: #dc2626;
+}
+
+.tcv-summary-budget.over-budget .tcv-summary-budget-label,
+.tcv-summary-budget.over-budget .tcv-summary-budget-pct {
+  color: #dc2626;
+}
+
+:root.dark .tcv-summary-budget-label {
+  color: #cbd5e1;
+}
+
+:root.dark .tcv-summary-budget-pct {
+  color: #64748b;
+}
+
+:root.dark .tcv-summary-budget.over-budget,
+:root.dark .tcv-summary-budget.over-budget .tcv-summary-budget-label,
+:root.dark .tcv-summary-budget.over-budget .tcv-summary-budget-pct {
+  color: #f87171;
 }
 
 .tcv-summary-errors {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4220,6 +4220,52 @@ input, textarea, select, button {
   overflow-wrap: anywhere;
 }
 
+.plutus-script-context-body-json {
+  font-family: inherit;
+  font-size: 12px;
+  word-break: normal;
+  overflow-wrap: normal;
+  max-height: 360px;
+}
+
+.plutus-script-context-toggle {
+  display: inline-flex;
+  margin-left: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.plutus-script-context-toggle-btn {
+  background: none;
+  border: none;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: #64748b;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.plutus-script-context-toggle-btn + .plutus-script-context-toggle-btn {
+  border-left: 1px solid #e2e8f0;
+}
+
+.plutus-script-context-toggle-btn:hover {
+  background: #f1f5f9;
+  color: #334155;
+}
+
+.plutus-script-context-toggle-btn.active {
+  background: #e2e8f0;
+  color: #1e293b;
+  font-weight: 600;
+}
+
+.plutus-script-context-toggle ~ .plutus-script-context-copy {
+  margin-left: 6px;
+}
+
 .plutus-empty-state {
   flex: 1;
   display: flex;

--- a/src/components/TransactionCardView/index.tsx
+++ b/src/components/TransactionCardView/index.tsx
@@ -42,6 +42,111 @@ export type {
   CardanoNetwork 
 } from "./types";
 
+// Compact number formatter for large execution-unit counts (e.g. "1.2B").
+const compactFmt = new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 2 });
+
+function formatNum(value: bigint | number, compact: boolean): string {
+  if (compact) return compactFmt.format(typeof value === "bigint" ? value : BigInt(value));
+  return (typeof value === "bigint" ? value : BigInt(value)).toLocaleString();
+}
+
+function toBig(v: bigint | number): bigint {
+  return typeof v === "bigint" ? v : BigInt(v);
+}
+
+// Percentage of `value` against `max`, with one decimal place. Returns null
+// when max is missing or zero so callers can omit the "(x%)" suffix entirely
+// rather than printing a misleading "0.0%".
+function pctOf(value: bigint, max: bigint | null): number | null {
+  if (max === null || max <= BigInt(0)) return null;
+  return Number((value * BigInt(10000)) / max) / 100;
+}
+
+function BudgetStat({
+  label,
+  used,
+  max,
+  unit,
+  compact,
+}: {
+  label: string;
+  used: bigint | number;
+  max: bigint | number | undefined;
+  unit?: string;
+  compact: boolean;
+}) {
+  const usedBig = toBig(used);
+  const maxBig = max !== undefined && max !== null ? toBig(max) : null;
+  const overBudget = maxBig !== null && maxBig > BigInt(0) && usedBig > maxBig;
+  const pct = pctOf(usedBig, maxBig);
+
+  return (
+    <span className={`tcv-summary-stat tcv-summary-budget${overBudget ? " over-budget" : ""}`}>
+      <span className="tcv-summary-budget-label">{label}:</span>{" "}
+      {formatNum(usedBig, compact)}
+      {maxBig !== null && (
+        <>
+          {" / "}
+          {formatNum(maxBig, compact)}
+        </>
+      )}
+      {unit ? ` ${unit}` : ""}
+      {pct !== null && (
+        <span className="tcv-summary-budget-pct"> ({pct.toFixed(1)}%)</span>
+      )}
+    </span>
+  );
+}
+
+// Three-value stat: `actual (%) / declared (%) / max`, where each percentage
+// is against `max`. The actual segment is hidden until validation has run;
+// the max segment / percentages are hidden until protocol params are loaded.
+function ExUnitTripleStat({
+  label,
+  actual,
+  declared,
+  max,
+}: {
+  label: string;
+  actual: bigint | null;
+  declared: bigint;
+  max: bigint | null;
+}) {
+  const overBudget = max !== null && max > BigInt(0) && declared > max;
+  const actualPct = actual !== null ? pctOf(actual, max) : null;
+  const declaredPct = pctOf(declared, max);
+  const compact = true;
+
+  return (
+    <span className={`tcv-summary-stat tcv-summary-budget${overBudget ? " over-budget" : ""}`}>
+      <span className="tcv-summary-budget-label">{label}:</span>{" "}
+      {actual !== null && (
+        <>
+          <span title="Actual execution units calculated by running the scripts">
+            {formatNum(actual, compact)}
+            {actualPct !== null && (
+              <span className="tcv-summary-budget-pct"> ({actualPct.toFixed(1)}%)</span>
+            )}
+          </span>
+          {" / "}
+        </>
+      )}
+      <span title="Sum of ex_units declared on the redeemers (what gets charged in fees)">
+        {formatNum(declared, compact)}
+        {declaredPct !== null && (
+          <span className="tcv-summary-budget-pct"> ({declaredPct.toFixed(1)}%)</span>
+        )}
+      </span>
+      {max !== null && (
+        <>
+          {" / "}
+          <span title="Protocol per-tx maximum">{formatNum(max, compact)}</span>
+        </>
+      )}
+    </span>
+  );
+}
+
 // Top-level section block component
 interface TopLevelSectionProps {
   title: string;
@@ -181,6 +286,9 @@ export default function TransactionCardView({
   focusedPath,
   extractedHashes,
   inputUtxoInfoMap,
+  txCborHex,
+  protocolMaxes,
+  actualExUnits,
 }: TransactionCardViewProps): React.ReactElement {
   const diagnosticsMap = useMemo(() => buildDiagnosticsMap(diagnostics), [diagnostics]);
   const sundaeCtx = useMemo(() => {
@@ -231,6 +339,26 @@ export default function TransactionCardView({
   
   const inputCount = body.inputs?.length ?? 0;
   const outputCount = body.outputs?.length ?? 0;
+
+  // Tx size in bytes derived from the raw CBOR hex (2 hex chars per byte).
+  const txSize = txCborHex ? Math.floor(txCborHex.length / 2) : null;
+
+  // Sum of all redeemer-declared budgets; these are what gets charged against
+  // the protocol-level per-tx execution unit caps.
+  const { totalMem, totalSteps } = useMemo(() => {
+    let mem = BigInt(0);
+    let steps = BigInt(0);
+    for (const r of tx.witness_set.redeemers ?? []) {
+      try { mem += BigInt(r.ex_units.mem); } catch { /* ignore malformed */ }
+      try { steps += BigInt(r.ex_units.steps); } catch { /* ignore malformed */ }
+    }
+    return { totalMem: mem, totalSteps: steps };
+  }, [tx.witness_set.redeemers]);
+
+  const maxTxSize = protocolMaxes?.maxTxSize;
+  const maxMem = protocolMaxes?.maxTxExUnits?.mem;
+  const maxSteps = protocolMaxes?.maxTxExUnits?.steps;
+
   const certCount = body.certs?.length ?? 0;
   const vkeyCount = witnessSet.vkeys?.length ?? 0;
   const redeemerCount = witnessSet.redeemers?.length ?? 0;
@@ -279,6 +407,25 @@ export default function TransactionCardView({
             <span className="tcv-summary-stat">{inputCount} inputs</span>
             <span className="tcv-summary-stat">{outputCount} outputs</span>
             <span className="tcv-summary-stat">Fee: ₳ {formatAda(body.fee)}</span>
+            {txSize !== null && (
+              <BudgetStat label="Size" used={txSize} max={maxTxSize} unit="B" compact={false} />
+            )}
+            {(tx.witness_set.redeemers?.length ?? 0) > 0 && (
+              <>
+                <ExUnitTripleStat
+                  label="CPU"
+                  actual={actualExUnits ? actualExUnits.steps : null}
+                  declared={totalSteps}
+                  max={maxSteps ?? null}
+                />
+                <ExUnitTripleStat
+                  label="Mem"
+                  actual={actualExUnits ? actualExUnits.mem : null}
+                  declared={totalMem}
+                  max={maxMem ?? null}
+                />
+              </>
+            )}
           </div>
         </div>
         

--- a/src/components/TransactionCardView/types.ts
+++ b/src/components/TransactionCardView/types.ts
@@ -390,6 +390,20 @@ export interface TransactionCardViewProps {
   extractedHashes?: ExtractedHashes | null;
   /** Fetched UTxO info for transaction inputs from Koios */
   inputUtxoInfoMap?: InputUtxoInfoMap | null;
+  /** Raw transaction CBOR hex, used to display tx size in the summary */
+  txCborHex?: string | null;
+  /** Protocol limits used to render per-tx budget percentages in the summary */
+  protocolMaxes?: {
+    maxTxSize?: number;
+    maxTxExUnits?: { mem: bigint; steps: bigint };
+  } | null;
+  /**
+   * Sum of script-eval `calculated_ex_units` (the *actual* cost computed by
+   * running scripts), populated only after Validate has run. The redeemer's
+   * declared budget can over-estimate this; surfacing both lets the user spot
+   * over-declared budgets that waste fee.
+   */
+  actualExUnits?: { mem: bigint; steps: bigint } | null;
 }
 
 // Transaction types


### PR DESCRIPTION
## Summary

Two related Plutus-eval visibility improvements bundled together.

**Tx budget summary** (card view): shows tx size (B / max) plus per-tx CPU and Mem ex units as \`actual / declared / max\` once Validate has run. Surfaces over-declared budgets that waste fee, and over-budget cases get a warning style.

**Script context** (Plutus Scripts tab): per redeemer, a collapsible disclosure showing the hex CBOR of the script context the VM evaluated against, with byte count and copy button. Useful when off-chain code and an on-chain script disagree about what the context looks like.

## Dependency

The script-context section consumes a new \`script_context_bytes\` field on \`EvalRedeemerResult\` that cquisitor-lib does not yet expose — see cardananium/cquisitor-lib#5. **This PR will not type-check against \`@cardananium/cquisitor-lib@^0.1.0-beta.55\`**; it needs a beta bump after that lib PR merges and publishes. Marked draft for that reason — happy to bump and re-mark ready once the lib lands.

## Test plan
- [ ] Load a tx with redeemers; pre-validate, the summary shows declared/max only
- [ ] Run Validate on a tx with Plutus scripts; the summary picks up actual ex units, and each redeemer in the Plutus Scripts tab gets a Script Context disclosure showing hex CBOR
- [ ] Copy button on the script context copies the hex
- [ ] Over-declared budget renders with the warning style