### PR TITLE
improve OutsideValidityIntervalUTxO error message

### DIFF
--- a/src/components/ErrorDataFormatters.tsx
+++ b/src/components/ErrorDataFormatters.tsx
@@ -7,6 +7,7 @@ import { AddressWithTooltip } from "./AddressWithTooltip";
 import { CopyIcon, CheckIcon, XCircleIcon } from "./Icons";
 import { AssetsTable, type AssetRow } from "./AssetsTable";
 import { SlotWithTooltip } from "./TransactionCardView/components/SlotWithTooltip";
+import { formatDurationSeconds } from "@/utils/slotTime";
 
 // ============================================================================
 // Type Definitions
@@ -163,6 +164,25 @@ const ERROR_TYPE_MESSAGES: Record<string, (data?: Record<string, unknown>) => st
       return `Fee too small: ${Number(actualFee).toLocaleString()} < ${Number(minFee).toLocaleString()} lovelace required`;
     }
     return "Fee too small for this transaction";
+  },
+  OutsideValidityIntervalUTxO: (data) => {
+    const current = data?.current_slot ?? data?.currentSlot;
+    const start = data?.interval_start ?? data?.intervalStart;
+    const end = data?.interval_end ?? data?.intervalEnd;
+    if (current === undefined || start === undefined || end === undefined) {
+      return "Current slot is outside the transaction's validity interval";
+    }
+    const cur = BigInt(current as bigint | number | string);
+    const s = BigInt(start as bigint | number | string);
+    const e = BigInt(end as bigint | number | string);
+    const interval = `[${s.toString()}..${e.toString()}]`;
+    if (cur < s) {
+      return `Transaction validity interval ${interval} means the transaction won't become valid for ${formatDurationSeconds(Number(s - cur))}`;
+    }
+    if (cur > e) {
+      return `Transaction validity interval ${interval} means the transaction expired ${formatDurationSeconds(Number(cur - e))} ago`;
+    }
+    return `Transaction validity interval ${interval} contains current slot ${cur.toString()}`;
   },
   DelegationToRetiringPool: (data) => {
     const poolId = data?.pool_id ?? data?.poolId;

--- a/src/utils/slotTime.ts
+++ b/src/utils/slotTime.ts
@@ -25,16 +25,19 @@ export function formatSlotDate(slot: number | bigint, network: NetworkType): str
   return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`;
 }
 
-export function formatSlotRelative(slot: number | bigint, network: NetworkType, now: Date = new Date()): string {
-  const target = slotToDate(slot, network).getTime();
-  const diffSec = Math.round((target - now.getTime()) / 1000);
-  const abs = Math.abs(diffSec);
-  const future = diffSec >= 0;
-  const fmt = (n: number, unit: string) => `${n} ${unit}${n === 1 ? "" : "s"} ${future ? "from now" : "ago"}`;
+export function formatDurationSeconds(sec: number): string {
+  const abs = Math.abs(sec);
+  const fmt = (n: number, unit: string) => `${n} ${unit}${n === 1 ? "" : "s"}`;
   if (abs < 60) return fmt(abs, "second");
   if (abs < 3600) return fmt(Math.round(abs / 60), "minute");
   if (abs < 86400) return fmt(Math.round(abs / 3600), "hour");
   if (abs < 86400 * 30) return fmt(Math.round(abs / 86400), "day");
   if (abs < 86400 * 365) return fmt(Math.round(abs / (86400 * 30)), "month");
   return fmt(Math.round(abs / (86400 * 365)), "year");
+}
+
+export function formatSlotRelative(slot: number | bigint, network: NetworkType, now: Date = new Date()): string {
+  const target = slotToDate(slot, network).getTime();
+  const diffSec = Math.round((target - now.getTime()) / 1000);
+  return `${formatDurationSeconds(diffSec)} ${diffSec >= 0 ? "from now" : "ago"}`;
 }


### PR DESCRIPTION
Surface whether the tx hasn't yet become valid ("won't become valid for X minutes") or has already expired ("expired X minutes ago"), instead of just stating the interval and current slot.

Extract formatDurationSeconds from formatSlotRelative so the bare duration formatter can be reused by the error handler.

<img width="1202" height="200" alt="image" src="https://github.com/user-attachments/assets/a7622002-0d88-4895-95b2-c896465ebefd" />
