### PR TITLE
Add transaction submission via Koios / Blockfrost

### DIFF
--- a/src/app/TransactionValidatorContent.tsx
+++ b/src/app/TransactionValidatorContent.tsx
@@ -23,7 +23,7 @@ import {
   CheckIcon,
   ExternalLinkIcon,
 } from "@/components/Icons";
-import { buildCardanoCborUrl, buildTxStudioUrl, openExternalUrl } from "@/utils/externalApps";
+import { buildCardanoCborUrl, buildExplorerTxUrl, buildTxStudioUrl, openExternalUrl } from "@/utils/externalApps";
 import { buildJsonViewerUrl } from "@/utils/jsonViewerHandoff";
 import { ErrorDataDetails, getCleanedErrorMessage, DecompositionModalProvider } from "@/components/ErrorDataFormatters";
 import HintBanner from "@/components/HintBanner";
@@ -31,9 +31,11 @@ import HelpTooltip from "@/components/HelpTooltip";
 import EmptyStatePlaceholder from "@/components/EmptyStatePlaceholder";
 import ShareButton from "@/components/ShareButton";
 import {
+  submitTransaction,
   validateTransaction,
   validateTransactionWithContext,
   buildValidationContext,
+  type DataProvider,
   type NetworkType,
 } from "@/utils/transactionValidation";
 import { decode_specific_type, extract_hashes_from_transaction_js } from "@cardananium/cquisitor-lib";
@@ -639,6 +641,128 @@ function PlutusScriptResults({ results }: { results: EvalRedeemerResult[] }) {
         );
       })}
     </Accordion.Root>
+  );
+}
+
+interface SubmitPanelProps {
+  txHex: string;
+  network: NetworkType;
+  provider: DataProvider;
+  apiKey: string;
+}
+
+function SubmitTransactionPanel({ txHex, network, provider, apiKey }: SubmitPanelProps) {
+  type Status = "idle" | "confirming" | "submitting" | "success" | "error";
+  const [status, setStatus] = useState<Status>("idle");
+  const [submittedHash, setSubmittedHash] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const confirmTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => () => {
+    if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current);
+  }, []);
+
+  const providerLabel = provider === "blockfrost" ? "Blockfrost" : "Koios";
+  const networkLabel = network.charAt(0).toUpperCase() + network.slice(1);
+  const hasKey = !!apiKey.trim();
+
+  const handleClick = async () => {
+    if (status === "submitting") return;
+    if (status === "idle" || status === "error") {
+      setSubmitError(null);
+      setStatus("confirming");
+      if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current);
+      confirmTimeoutRef.current = setTimeout(() => {
+        setStatus((s) => (s === "confirming" ? "idle" : s));
+      }, 5000);
+      return;
+    }
+    if (status === "confirming") {
+      if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current);
+      setStatus("submitting");
+      try {
+        const hash = await submitTransaction({ txHex, network, provider, apiKey: apiKey.trim() });
+        setSubmittedHash(hash);
+        setStatus("success");
+      } catch (e) {
+        setSubmitError(e instanceof Error ? e.message : "Submission failed");
+        setStatus("error");
+      }
+    }
+  };
+
+  const handleCopyHash = async () => {
+    if (!submittedHash) return;
+    try {
+      await navigator.clipboard.writeText(submittedHash);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch { /* ignore */ }
+  };
+
+  if (status === "success" && submittedHash) {
+    return (
+      <div className="submit-panel submit-panel-success">
+        <div className="submit-panel-header">
+          <SuccessIcon />
+          <span>Submitted to {networkLabel} via {providerLabel}</span>
+        </div>
+        <div className="submit-panel-hash-row">
+          <code className="submit-panel-hash">{submittedHash}</code>
+          <button
+            className="submit-panel-copy-btn"
+            onClick={handleCopyHash}
+            title="Copy transaction hash"
+          >
+            {copied ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+            {copied ? "Copied!" : "Copy"}
+          </button>
+          <button
+            className="submit-panel-explorer-btn"
+            onClick={() => openExternalUrl(buildExplorerTxUrl(submittedHash, network))}
+            title="Open in Cardanoscan"
+          >
+            <ExternalLinkIcon size={12} />
+            Explorer
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const buttonLabel =
+    status === "submitting"
+      ? "Submitting..."
+      : status === "confirming"
+        ? `Click again to confirm submission to ${networkLabel}`
+        : `Submit to ${networkLabel} via ${providerLabel}`;
+
+  return (
+    <div className={`submit-panel ${status === "confirming" ? "submit-panel-confirming" : ""}`}>
+      <button
+        className={`submit-panel-btn ${status === "confirming" ? "confirming" : ""}`}
+        onClick={handleClick}
+        disabled={!hasKey || status === "submitting"}
+        title={hasKey ? undefined : `Enter a ${providerLabel} API key to submit`}
+      >
+        {status === "submitting" ? (
+          <SpinnerIcon size={16} className="animate-spin" />
+        ) : (
+          <CheckCircleIcon size={16} />
+        )}
+        <span>{buttonLabel}</span>
+      </button>
+      {!hasKey && (
+        <p className="submit-panel-hint">Enter a {providerLabel} API key above to enable submission.</p>
+      )}
+      {submitError && (
+        <div className="submit-panel-error">
+          <DiagnosticIcon severity="error" />
+          <span>{submitError}</span>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -1378,7 +1502,18 @@ export default function TransactionValidatorContent() {
 
         <Tabs.Content value="validation" className="validator-tab-content">
           {result ? (
-            <DiagnosticsList items={diagnostics} onLocationClick={handleLocationClick} />
+            <>
+              <DiagnosticsList items={diagnostics} onLocationClick={handleLocationClick} />
+              {result.errors.length === 0 && result.phase2_errors.length === 0 && txCborHex && (
+                <SubmitTransactionPanel
+                  key={`${txCborHex}|${network}|${provider}`}
+                  txHex={txCborHex}
+                  network={network}
+                  provider={provider}
+                  apiKey={apiKey}
+                />
+              )}
+            </>
           ) : (
             <div className="empty-state">
               <p className="empty-hint">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3665,6 +3665,131 @@ input, textarea, select, button {
   transform: none;
 }
 
+/* Submit panel — shown in the Validation Result tab when a transaction is valid */
+.submit-panel {
+  margin: 12px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.submit-panel-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: linear-gradient(135deg, #16a34a, #15803d);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  box-shadow: 0 2px 8px rgba(22, 163, 74, 0.25);
+}
+
+.submit-panel-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, #15803d, #166534);
+  box-shadow: 0 4px 12px rgba(22, 163, 74, 0.35);
+  transform: translateY(-1px);
+}
+
+.submit-panel-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.submit-panel-btn.confirming {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.35);
+  animation: submit-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes submit-pulse {
+  0%, 100% { box-shadow: 0 2px 8px rgba(245, 158, 11, 0.35); }
+  50% { box-shadow: 0 4px 16px rgba(245, 158, 11, 0.6); }
+}
+
+.submit-panel-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-muted, #6b7280);
+}
+
+.submit-panel-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #991b1b;
+  word-break: break-word;
+}
+
+.submit-panel-success {
+  padding: 12px;
+  background: #f0fdf4;
+  border: 1px solid #86efac;
+  border-radius: 8px;
+}
+
+.submit-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #15803d;
+  margin-bottom: 8px;
+}
+
+.submit-panel-hash-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.submit-panel-hash {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  padding: 6px 8px;
+  background: white;
+  border: 1px solid #d1fae5;
+  border-radius: 4px;
+  color: #14532d;
+  word-break: break-all;
+}
+
+.submit-panel-copy-btn,
+.submit-panel-explorer-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  background: white;
+  color: #15803d;
+  border: 1px solid #86efac;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.submit-panel-copy-btn:hover,
+.submit-panel-explorer-btn:hover {
+  background: #f0fdf4;
+}
+
 /* Status badge */
 .validator-status-badge {
   margin: 8px 16px;

--- a/src/utils/blockfrostClient.ts
+++ b/src/utils/blockfrostClient.ts
@@ -48,6 +48,17 @@ export interface BlockfrostClientConfig {
 
 const PREDEFINED_DREPS = new Set(["AlwaysAbstain", "AlwaysNoConfidence"]);
 
+function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) throw new Error("Invalid hex: odd length");
+  const buf = new ArrayBuffer(clean.length / 2);
+  const out = new Uint8Array(buf);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
 // --- Raw Blockfrost shapes (only what we consume) ------------------------
 
 interface BfBlock {
@@ -791,6 +802,27 @@ export class BlockfrostClient implements BlockchainDataClient {
       )
     );
     return results.filter((r): r is KoiosTxCborResponse => r !== null);
+  }
+
+  async submitTransaction(txHex: string): Promise<string> {
+    const bytes = hexToBytes(txHex);
+    const response = await fetch(`${this.baseUrl}/tx/submit`, {
+      method: "POST",
+      headers: {
+        project_id: this.apiKey,
+        "Content-Type": "application/cbor",
+        Accept: "application/json",
+      },
+      body: new Blob([bytes], { type: "application/cbor" }),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Blockfrost submit error: ${response.status} ${response.statusText}${body ? ` — ${body}` : ""}`
+      );
+    }
+    const txHash = await response.json();
+    return typeof txHash === "string" ? txHash : String(txHash);
   }
 
   // --- Helpers shared across methods --------------------------------------

--- a/src/utils/externalApps.ts
+++ b/src/utils/externalApps.ts
@@ -36,6 +36,16 @@ export function buildCardanoCborUrl(cborHex: string, type?: string): string {
   return `${window.location.origin}${path}/#cardano-cbor?${params.toString()}`;
 }
 
+const CARDANOSCAN_HOSTS: Record<NetworkType, string> = {
+  mainnet: "https://cardanoscan.io",
+  preview: "https://preview.cardanoscan.io",
+  preprod: "https://preprod.cardanoscan.io",
+};
+
+export function buildExplorerTxUrl(txHash: string, network: NetworkType): string {
+  return `${CARDANOSCAN_HOSTS[network]}/transaction/${txHash}`;
+}
+
 export function openExternalUrl(url: string): void {
   if (typeof window === "undefined") return;
   window.open(url, "_blank", "noopener,noreferrer");

--- a/src/utils/koiosClient.ts
+++ b/src/utils/koiosClient.ts
@@ -49,6 +49,18 @@ export interface BlockchainDataClient {
   getLastEnactedProposals(proposalTypes: string[]): Promise<KoiosProposal[]>;
   getEpochParams(epochNo?: number): Promise<KoiosEpochParams[]>;
   getTxCbor(txHashes: string[]): Promise<KoiosTxCborResponse[]>;
+  submitTransaction(txHex: string): Promise<string>;
+}
+
+function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) throw new Error('Invalid hex: odd length');
+  const buf = new ArrayBuffer(clean.length / 2);
+  const out = new Uint8Array(buf);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.substr(i * 2, 2), 16);
+  }
+  return out;
 }
 
 /**
@@ -269,6 +281,28 @@ export class KoiosClient implements BlockchainDataClient {
       _tx_hashes: txHashes,
     };
     return this.post<KoiosTxCborResponse[], KoiosTxHashesRequest>('/tx_cbor', body);
+  }
+
+  async submitTransaction(txHex: string): Promise<string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/cbor',
+      Accept: 'application/json',
+    };
+    if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+    const bytes = hexToBytes(txHex);
+    const response = await fetch(`${this.baseUrl}/submit/tx`, {
+      method: 'POST',
+      headers,
+      body: new Blob([bytes], { type: 'application/cbor' }),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(
+        `Koios submit error: ${response.status} ${response.statusText}${body ? ` — ${body}` : ''}`
+      );
+    }
+    const txHash = await response.json();
+    return typeof txHash === 'string' ? txHash : String(txHash);
   }
 }
 

--- a/src/utils/transactionValidation.ts
+++ b/src/utils/transactionValidation.ts
@@ -119,6 +119,20 @@ function mapToKoiosNetwork(network: NetworkType): KoiosNetworkType {
   return network;
 }
 
+export interface SubmitTransactionConfig {
+  txHex: string;
+  network: NetworkType;
+  provider: DataProvider;
+  apiKey: string;
+}
+
+export async function submitTransaction(
+  config: SubmitTransactionConfig
+): Promise<string> {
+  const client = makeClient(config.provider, mapToKoiosNetwork(config.network), config.apiKey);
+  return client.submitTransaction(config.txHex);
+}
+
 // ============================================================================
 // UTxO Conversion Functions
 // ============================================================================


### PR DESCRIPTION
When a validated transaction has no phase-1 or phase-2 errors, a Submit panel appears in the Validation Result tab. Two-click confirm to guard against misclicks (warnings still permit submission). On success, shows the tx hash with copy + Cardanoscan link; on failure, surfaces the provider's error message.

<img width="2465" height="1394" alt="image" src="https://github.com/user-attachments/assets/0d327bfd-af77-4c9c-b2f8-94116d779b03" />

<img width="1250" height="241" alt="image" src="https://github.com/user-attachments/assets/f452e6db-2b58-442f-a4ab-5c6234d1a044" />

<img width="1237" height="167" alt="image" src="https://github.com/user-attachments/assets/b141b9a9-6212-4772-a674-aa4286c821f3" />
