### PR TITLE
Add pasted witnesses to a transaction's witness set

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,11 @@
     "": {
       "name": "cquisitor",
       "dependencies": {
-        "@cardananium/cquisitor-lib": "^0.1.0-beta.56",
+        "@cardananium/cquisitor-lib": "^0.1.0-beta.57",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.6",
+        "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.0.1",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -81,7 +82,7 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@cardananium/cquisitor-lib": ["@cardananium/cquisitor-lib@0.1.0-beta.56", "", {}, "sha512-+dwCcmknJiOX4LMDysX/JlrP7m6EWTJX1kibBoF155qFFlgbUUYZEsWgwV0old7Kry4p9HWa0gFQRmVVMGQ0kQ=="],
+    "@cardananium/cquisitor-lib": ["@cardananium/cquisitor-lib@0.1.0-beta.57", "", {}, "sha512-mqvdaFvS9Khz+MICSCdEDw015ALe4juO++nYX7aj4+5DIhnt3GCuim6etLcqL4BEVQ9LdZJPQRpR2KjCp4GbGQ=="],
 
     "@cbor-extract/cbor-extract-darwin-arm64": ["@cbor-extract/cbor-extract-darwin-arm64@2.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w=="],
 
@@ -256,6 +257,8 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw=="],
+
+    "@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
@@ -1094,6 +1097,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@noble/curves/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
     "@radix-ui/react-progress/@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.6",
+    "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.0.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/src/app/TransactionValidatorContent.tsx
+++ b/src/app/TransactionValidatorContent.tsx
@@ -44,6 +44,14 @@ import { convertSerdeNumbers } from "@/utils/serdeNumbers";
 import { reorderTransactionFields } from "@/utils/reorderTransactionFields";
 import { normalizeHexOrBase64 } from "@/utils/inputNormalization";
 import {
+  parseWitnessInput,
+  addVkeyWitnesses,
+  txBodyHash,
+  verifySignature,
+  vkeyHash,
+  WitnessParseError,
+} from "@/utils/witnessInsertion";
+import {
   useTransactionValidator,
   type DecodedTransaction,
   type InputUtxoInfoMap,
@@ -237,9 +245,154 @@ function formatDiagnosticsToMarkdown(items: DiagnosticItem[]): string {
   return md.trim();
 }
 
-function DiagnosticsList({ items, onLocationClick }: { 
-  items: DiagnosticItem[]; 
+// Inline panel for resolving a "missing vkey witness" error: paste a signature
+// in any common format and it's verified against the transaction and spliced
+// into the witness set (the body bytes — and therefore the tx hash — are left
+// untouched, so existing signatures stay valid).
+interface AddWitnessPanelProps {
+  txHex: string;
+  missingKeyHash?: string;
+  onWitnessAdded: (newHex: string) => void;
+}
+
+function AddWitnessPanel({ txHex, missingKeyHash, onWitnessAdded }: AddWitnessPanelProps) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+  const [feedback, setFeedback] = useState<
+    { kind: "success" | "error" | "warning"; text: string } | null
+  >(null);
+
+  const handleAdd = () => {
+    setFeedback(null);
+
+    let witnesses;
+    try {
+      witnesses = parseWitnessInput(value);
+    } catch (e) {
+      setFeedback({
+        kind: "error",
+        text: e instanceof WitnessParseError ? e.message : "Could not parse the pasted witness.",
+      });
+      return;
+    }
+
+    let bodyHash: Uint8Array;
+    try {
+      bodyHash = txBodyHash(txHex);
+    } catch {
+      setFeedback({ kind: "error", text: "Could not read the transaction body to verify the signature." });
+      return;
+    }
+
+    // Cryptographically verify every signature against this transaction.
+    const verified = witnesses.map((w) => ({ w, ok: verifySignature(bodyHash, w) }));
+    const valid = verified.filter((v) => v.ok).map((v) => v.w);
+    const invalidCount = verified.length - valid.length;
+
+    if (valid.length === 0) {
+      setFeedback({
+        kind: "error",
+        text:
+          "Signature does not match this transaction — it was signed for a different transaction, or by a different key.",
+      });
+      return;
+    }
+
+    let result;
+    try {
+      result = addVkeyWitnesses(txHex, valid);
+    } catch (e) {
+      setFeedback({ kind: "error", text: e instanceof Error ? e.message : "Failed to insert the witness." });
+      return;
+    }
+
+    if (result.added === 0) {
+      setFeedback({
+        kind: "warning",
+        text:
+          result.duplicates > 0
+            ? "That signature is already in the witness set."
+            : "No new signatures to add.",
+      });
+      return;
+    }
+
+    const addedHashes = valid.map((w) => vkeyHash(w.vkey));
+    const matchesThis = missingKeyHash ? addedHashes.includes(missingKeyHash.toLowerCase()) : true;
+
+    const parts = [`Added ${result.added} signature${result.added > 1 ? "s" : ""}.`];
+    if (result.duplicates > 0) parts.push(`${result.duplicates} already present.`);
+    if (invalidCount > 0) parts.push(`${invalidCount} skipped (didn't match this transaction).`);
+    if (missingKeyHash && !matchesThis) {
+      parts.push("Note: this isn't the key this error needs — re-validate to see what's still required.");
+    }
+    setFeedback({ kind: matchesThis ? "success" : "warning", text: parts.join(" ") });
+    setValue("");
+    onWitnessAdded(result.txHex);
+  };
+
+  if (!open) {
+    return (
+      <button
+        className="add-witness-toggle"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+      >
+        <CheckCircleIcon size={13} />
+        Add a signature for this key
+      </button>
+    );
+  }
+
+  return (
+    <div className="add-witness-panel" onClick={(e) => e.stopPropagation()}>
+      <textarea
+        className="add-witness-input"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={'Paste a witness — raw hex/base64, a cardano-cli witness file ({ "type": …, "cborHex": … }), or a full witness set'}
+        spellCheck={false}
+        rows={3}
+      />
+      <div className="add-witness-actions">
+        <button className="add-witness-btn" onClick={handleAdd} disabled={!value.trim()}>
+          <CheckCircleIcon size={14} />
+          Add to witness set
+        </button>
+        <button
+          className="add-witness-cancel"
+          onClick={() => {
+            setOpen(false);
+            setValue("");
+            setFeedback(null);
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+      {feedback && (
+        <div className={`add-witness-feedback add-witness-feedback-${feedback.kind}`}>
+          {feedback.kind === "success" ? (
+            <SuccessIcon size={14} />
+          ) : feedback.kind === "warning" ? (
+            <WarningIcon size={14} />
+          ) : (
+            <XCircleIcon size={14} />
+          )}
+          <span>{feedback.text}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiagnosticsList({ items, onLocationClick, txHex, onWitnessAdded }: {
+  items: DiagnosticItem[];
   onLocationClick?: (locations: string[]) => void;
+  txHex?: string | null;
+  onWitnessAdded?: (newHex: string) => void;
 }) {
   if (items.length === 0) {
     return (
@@ -298,6 +451,17 @@ function DiagnosticsList({ items, onLocationClick }: {
                   <div className="diagnostic-details">
                     {item.errorData && (
                       <ErrorDataDetails error={item.errorData} hint={item.hint} />
+                    )}
+                    {item.errorType === "MissingVKeyWitnesses" && txHex && onWitnessAdded && (
+                      <AddWitnessPanel
+                        txHex={txHex}
+                        missingKeyHash={
+                          typeof item.errorData?.missing_key_hash === "string"
+                            ? item.errorData.missing_key_hash
+                            : undefined
+                        }
+                        onWitnessAdded={onWitnessAdded}
+                      />
                     )}
                     {item.details && (
                       <div className="diagnostic-detail-row">
@@ -1074,6 +1238,26 @@ export default function TransactionValidatorContent() {
   const handleValidate = useCallback(() => runValidation(false), [runValidation]);
   const handleRefetch = useCallback(() => runValidation(true), [runValidation]);
 
+  // Called after a witness is spliced into the transaction. Adding a signature
+  // leaves the body bytes (and tx hash) unchanged, so the already-fetched
+  // validation context is still valid — re-run validation against it locally,
+  // with no extra API calls, so the resolved error disappears immediately.
+  const handleWitnessAdded = useCallback(
+    (newHex: string) => {
+      setTxInput(newHex);
+      if (fetchedContext) {
+        try {
+          const ctx = buildValidationContext(fetchedContext, network);
+          setResult(validateTransactionWithContext(newHex, ctx));
+        } catch {
+          // If local re-validation fails for any reason, the input is still
+          // updated — the user can click Validate to re-run normally.
+        }
+      }
+    },
+    [setTxInput, setResult, fetchedContext, network]
+  );
+
   // Build diagnostics list from validation result (excluding redeemer results)
   const diagnostics: DiagnosticItem[] = [];
   if (result) {
@@ -1503,7 +1687,12 @@ export default function TransactionValidatorContent() {
         <Tabs.Content value="validation" className="validator-tab-content">
           {result ? (
             <>
-              <DiagnosticsList items={diagnostics} onLocationClick={handleLocationClick} />
+              <DiagnosticsList
+                items={diagnostics}
+                onLocationClick={handleLocationClick}
+                txHex={txCborHex}
+                onWitnessAdded={handleWitnessAdded}
+              />
               {result.errors.length === 0 && result.phase2_errors.length === 0 && txCborHex && (
                 <SubmitTransactionPanel
                   key={`${txCborHex}|${network}|${provider}`}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3673,6 +3673,130 @@ input, textarea, select, button {
   gap: 8px;
 }
 
+/* Inline "add a signature" panel shown under a missing-vkey-witness error */
+.add-witness-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--primary, #3182ce);
+  background: transparent;
+  border: 1px dashed var(--primary, #3182ce);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.add-witness-toggle:hover {
+  background: rgba(49, 130, 206, 0.08);
+}
+
+.add-witness-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 10px;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+}
+
+.add-witness-input {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 8px;
+  color: var(--foreground, #1a202c);
+  background: var(--background, #fff);
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  word-break: break-all;
+}
+
+.add-witness-input:focus {
+  outline: none;
+  border-color: var(--primary, #3182ce);
+}
+
+.add-witness-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.add-witness-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: white;
+  background: linear-gradient(135deg, #3182ce, #2b6cb0);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.add-witness-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, #2b6cb0, #2c5282);
+}
+
+.add-witness-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.add-witness-cancel {
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted, #6b7280);
+  background: transparent;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.add-witness-cancel:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.add-witness-feedback {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  border-radius: 6px;
+  word-break: break-word;
+}
+
+.add-witness-feedback-success {
+  color: #15803d;
+  background: #f0fdf4;
+  border: 1px solid #86efac;
+}
+
+.add-witness-feedback-warning {
+  color: #92400e;
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+}
+
+.add-witness-feedback-error {
+  color: #991b1b;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+}
+
 .submit-panel-btn {
   display: inline-flex;
   align-items: center;

--- a/src/utils/witnessInsertion.ts
+++ b/src/utils/witnessInsertion.ts
@@ -1,0 +1,463 @@
+// Insert vkey (signature) witnesses into a transaction's witness set.
+//
+// The cardinal rule: never re-encode the transaction body. The transaction id
+// (and therefore every signature) is the blake2b-256 hash of the body's exact
+// CBOR bytes. So we walk the transaction at the byte level, rebuild only the
+// witness-set element, and splice it back in place — leaving the body, the
+// is_valid flag, and the auxiliary data byte-for-byte untouched.
+//
+// Accepted paste formats (parseWitnessInput):
+//   - raw hex or base64 of any of the below
+//   - cardano-cli text envelope JSON: { "type": ..., "cborHex": "8200825820..." }
+//   - a full witness set map:        a100 81 82 5820<vkey> 5840<sig>
+//   - a cli witness envelope:        82 00 82 5820<vkey> 5840<sig>   ([tag, witness])
+//   - a bare vkey witness:           82 5820<vkey> 5840<sig>
+//   - a full signed transaction (its vkey witnesses are extracted)
+
+import { blake2b } from "@noble/hashes/blake2.js";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { normalizeHexOrBase64 } from "./inputNormalization";
+
+export interface VkeyWitness {
+  vkey: Uint8Array; // 32-byte ed25519 public key
+  signature: Uint8Array; // 64-byte ed25519 signature
+}
+
+// ---------------------------------------------------------------------------
+// hex helpers
+// ---------------------------------------------------------------------------
+
+export function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error("Hex string has an odd length");
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const byte = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) throw new Error("Hex string contains non-hex characters");
+    out[i] = byte;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal CBOR reader that tracks byte offsets
+// ---------------------------------------------------------------------------
+
+const MAJOR_UNSIGNED = 0;
+const MAJOR_BYTES = 2;
+const MAJOR_ARRAY = 4;
+const MAJOR_MAP = 5;
+const MAJOR_TAG = 6;
+const MAJOR_SIMPLE = 7;
+const INDEFINITE = 31;
+const BREAK = 0xff;
+
+interface Head {
+  major: number;
+  ai: number; // additional info (low 5 bits)
+  arg: number; // decoded argument (length / value); meaningless when indefinite
+  indefinite: boolean;
+  headEnd: number; // offset just past the head bytes
+}
+
+function readHead(buf: Uint8Array, pos: number): Head {
+  if (pos >= buf.length) throw new Error("Unexpected end of CBOR input");
+  const initial = buf[pos];
+  const major = initial >> 5;
+  const ai = initial & 0x1f;
+  let arg = 0;
+  let headEnd = pos + 1;
+  let indefinite = false;
+  if (ai < 24) {
+    arg = ai;
+  } else if (ai === 24) {
+    arg = buf[headEnd];
+    headEnd += 1;
+  } else if (ai === 25) {
+    arg = (buf[headEnd] << 8) | buf[headEnd + 1];
+    headEnd += 2;
+  } else if (ai === 26) {
+    arg = buf[headEnd] * 2 ** 24 + (buf[headEnd + 1] << 16) + (buf[headEnd + 2] << 8) + buf[headEnd + 3];
+    headEnd += 4;
+  } else if (ai === 27) {
+    // 8-byte argument. Lengths this large never appear in our structures, but
+    // we still advance the cursor correctly so skipItem stays in sync.
+    let v = 0;
+    for (let i = 0; i < 8; i++) v = v * 256 + buf[headEnd + i];
+    arg = v;
+    headEnd += 8;
+  } else if (ai === INDEFINITE) {
+    indefinite = true;
+  } else {
+    throw new Error(`Reserved CBOR additional info ${ai}`);
+  }
+  if (headEnd > buf.length) throw new Error("Unexpected end of CBOR input");
+  return { major, ai, arg, indefinite, headEnd };
+}
+
+// Advance past one complete CBOR item, returning the offset just past it.
+function skipItem(buf: Uint8Array, pos: number): number {
+  const h = readHead(buf, pos);
+  switch (h.major) {
+    case MAJOR_UNSIGNED:
+    case 1: // negative
+      return h.headEnd;
+    case MAJOR_BYTES:
+    case 3: // text string
+      if (h.indefinite) {
+        let p = h.headEnd;
+        while (buf[p] !== BREAK) p = skipItem(buf, p);
+        return p + 1;
+      }
+      return h.headEnd + h.arg;
+    case MAJOR_ARRAY: {
+      let p = h.headEnd;
+      if (h.indefinite) {
+        while (buf[p] !== BREAK) p = skipItem(buf, p);
+        return p + 1;
+      }
+      for (let i = 0; i < h.arg; i++) p = skipItem(buf, p);
+      return p;
+    }
+    case MAJOR_MAP: {
+      let p = h.headEnd;
+      if (h.indefinite) {
+        while (buf[p] !== BREAK) {
+          p = skipItem(buf, p); // key
+          p = skipItem(buf, p); // value
+        }
+        return p + 1;
+      }
+      for (let i = 0; i < h.arg; i++) {
+        p = skipItem(buf, p); // key
+        p = skipItem(buf, p); // value
+      }
+      return p;
+    }
+    case MAJOR_TAG:
+      return skipItem(buf, h.headEnd); // tag wraps exactly one item
+    case MAJOR_SIMPLE:
+      // floats/simple values: any payload is already counted in headEnd
+      return h.headEnd;
+    default:
+      throw new Error(`Unsupported CBOR major type ${h.major}`);
+  }
+}
+
+// Read a byte string item, returning its content and the offset past it.
+function readByteString(buf: Uint8Array, pos: number): { bytes: Uint8Array; next: number } {
+  const h = readHead(buf, pos);
+  if (h.major !== MAJOR_BYTES || h.indefinite) {
+    throw new Error("Expected a definite-length byte string");
+  }
+  const start = h.headEnd;
+  const end = start + h.arg;
+  if (end > buf.length) throw new Error("Byte string runs past end of input");
+  return { bytes: buf.slice(start, end), next: end };
+}
+
+// ---------------------------------------------------------------------------
+// CBOR writers (definite-length, canonical head encoding)
+// ---------------------------------------------------------------------------
+
+function encodeHead(major: number, arg: number): Uint8Array {
+  const tag = major << 5;
+  if (arg < 24) return new Uint8Array([tag | arg]);
+  if (arg < 0x100) return new Uint8Array([tag | 24, arg]);
+  if (arg < 0x10000) return new Uint8Array([tag | 25, arg >> 8, arg & 0xff]);
+  if (arg < 0x100000000) {
+    return new Uint8Array([tag | 26, (arg >>> 24) & 0xff, (arg >> 16) & 0xff, (arg >> 8) & 0xff, arg & 0xff]);
+  }
+  throw new Error("Argument too large to encode");
+}
+
+function encodeByteString(bytes: Uint8Array): Uint8Array {
+  return concatBytes(encodeHead(MAJOR_BYTES, bytes.length), bytes);
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+// Encode a single vkey witness as [vkey, signature].
+function encodeVkeyWitness(w: VkeyWitness): Uint8Array {
+  return concatBytes(encodeHead(MAJOR_ARRAY, 2), encodeByteString(w.vkey), encodeByteString(w.signature));
+}
+
+// ---------------------------------------------------------------------------
+// Witness input parsing
+// ---------------------------------------------------------------------------
+
+// Pull every [vkey, signature] pair out of a definite/indefinite array that is
+// the value of witness-set key 0.
+function readVkeyArray(buf: Uint8Array, pos: number): VkeyWitness[] {
+  const h = readHead(buf, pos);
+  if (h.major !== MAJOR_ARRAY) throw new Error("vkey witnesses are not an array");
+  const out: VkeyWitness[] = [];
+  let p = h.headEnd;
+  const readOne = () => {
+    const item = readHead(buf, p);
+    if (item.major !== MAJOR_ARRAY || item.arg !== 2) throw new Error("malformed vkey witness");
+    const vk = readByteString(buf, item.headEnd);
+    const sig = readByteString(buf, vk.next);
+    out.push({ vkey: vk.bytes, signature: sig.bytes });
+    p = sig.next;
+  };
+  if (h.indefinite) {
+    while (buf[p] !== BREAK) readOne();
+  } else {
+    for (let i = 0; i < h.arg; i++) readOne();
+  }
+  return out;
+}
+
+// Find witness-set key 0 inside a map and return its vkey witnesses (or []).
+function vkeysFromWitnessSetMap(buf: Uint8Array, pos: number): VkeyWitness[] {
+  const h = readHead(buf, pos);
+  if (h.major !== MAJOR_MAP) throw new Error("not a map");
+  let p = h.headEnd;
+  const entries = h.indefinite ? Infinity : h.arg;
+  for (let i = 0; i < entries; i++) {
+    if (h.indefinite && buf[p] === BREAK) break;
+    const keyHead = readHead(buf, p);
+    const valuePos = keyHead.headEnd;
+    if (keyHead.major === MAJOR_UNSIGNED && keyHead.arg === 0) {
+      return readVkeyArray(buf, valuePos);
+    }
+    p = skipItem(buf, valuePos); // skip this value
+  }
+  return [];
+}
+
+export class WitnessParseError extends Error {}
+
+// Parse pasted witness text (any supported format) into vkey witnesses.
+export function parseWitnessInput(text: string): VkeyWitness[] {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) throw new WitnessParseError("Nothing to add — paste a witness first.");
+
+  // Text-envelope JSON: { "type": ..., "description": ..., "cborHex": "..." }
+  let hex: string;
+  if (trimmed.startsWith("{")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      throw new WitnessParseError("Input looks like JSON but could not be parsed.");
+    }
+    const cborHex = (parsed as { cborHex?: unknown })?.cborHex;
+    if (typeof cborHex !== "string") {
+      throw new WitnessParseError('JSON is missing a string "cborHex" field.');
+    }
+    hex = cborHex.trim();
+    if (!/^[0-9a-fA-F]+$/.test(hex)) {
+      throw new WitnessParseError('"cborHex" is not valid hex.');
+    }
+  } else {
+    hex = normalizeHexOrBase64(trimmed).hex;
+    if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length === 0) {
+      throw new WitnessParseError("Input is not valid hex or base64.");
+    }
+  }
+
+  let buf: Uint8Array;
+  try {
+    buf = hexToBytes(hex);
+  } catch (e) {
+    throw new WitnessParseError(e instanceof Error ? e.message : "Could not decode hex.");
+  }
+
+  let witnesses: VkeyWitness[];
+  try {
+    witnesses = decodeWitnessBytes(buf);
+  } catch (e) {
+    throw new WitnessParseError(
+      `Could not interpret this as a witness: ${e instanceof Error ? e.message : "unknown CBOR error"}`,
+    );
+  }
+
+  for (const w of witnesses) {
+    if (w.vkey.length !== 32) throw new WitnessParseError("Public key is not 32 bytes.");
+    if (w.signature.length !== 64) throw new WitnessParseError("Signature is not 64 bytes.");
+  }
+  if (witnesses.length === 0) {
+    throw new WitnessParseError("No vkey (signature) witnesses found in the input.");
+  }
+  return witnesses;
+}
+
+function decodeWitnessBytes(buf: Uint8Array): VkeyWitness[] {
+  const h = readHead(buf, 0);
+
+  // A full witness set map: { 0: [...], 1: [...], ... }
+  if (h.major === MAJOR_MAP) {
+    return vkeysFromWitnessSetMap(buf, 0);
+  }
+
+  if (h.major === MAJOR_ARRAY) {
+    // A full signed transaction: [body(map), witness_set(map), is_valid?, aux?]
+    if (!h.indefinite && (h.arg === 3 || h.arg === 4)) {
+      const first = readHead(buf, h.headEnd);
+      if (first.major === MAJOR_MAP) {
+        const bodyEnd = skipItem(buf, h.headEnd);
+        return vkeysFromWitnessSetMap(buf, bodyEnd);
+      }
+    }
+
+    if (!h.indefinite && h.arg === 2) {
+      const first = readHead(buf, h.headEnd);
+      // cli witness envelope: [tag, witness]; tag 0 == key witness
+      if (first.major === MAJOR_UNSIGNED) {
+        if (first.arg !== 0) {
+          throw new Error(`unsupported witness tag ${first.arg} (only key witnesses are supported)`);
+        }
+        return [readSingleVkeyWitness(buf, first.headEnd)];
+      }
+      // bare vkey witness: [vkey, signature]
+      if (first.major === MAJOR_BYTES) {
+        return [readSingleVkeyWitness(buf, 0)];
+      }
+    }
+
+    // An array of bare witnesses: [[vkey, sig], [vkey, sig], ...]
+    return readVkeyArray(buf, 0);
+  }
+
+  throw new Error("unrecognized top-level CBOR structure");
+}
+
+function readSingleVkeyWitness(buf: Uint8Array, pos: number): VkeyWitness {
+  const h = readHead(buf, pos);
+  if (h.major !== MAJOR_ARRAY || h.arg !== 2) throw new Error("witness is not a 2-element array");
+  const vk = readByteString(buf, h.headEnd);
+  const sig = readByteString(buf, vk.next);
+  return { vkey: vk.bytes, signature: sig.bytes };
+}
+
+// ---------------------------------------------------------------------------
+// Transaction structure (offsets only — bytes are never decoded/re-encoded)
+// ---------------------------------------------------------------------------
+
+interface TxLayout {
+  bodyStart: number;
+  bodyEnd: number;
+  wsetStart: number;
+  wsetEnd: number;
+}
+
+function locateTxParts(buf: Uint8Array): TxLayout {
+  const h = readHead(buf, 0);
+  if (h.major !== MAJOR_ARRAY) throw new Error("Transaction is not a CBOR array");
+  if (h.indefinite) throw new Error("Indefinite-length transaction array is not supported");
+  if (h.arg < 2) throw new Error("Transaction array is too short");
+  const bodyStart = h.headEnd;
+  const bodyEnd = skipItem(buf, bodyStart);
+  const wsetStart = bodyEnd;
+  const wsetEnd = skipItem(buf, wsetStart);
+  return { bodyStart, bodyEnd, wsetStart, wsetEnd };
+}
+
+export interface AddWitnessResult {
+  txHex: string;
+  added: number; // newly inserted witnesses
+  duplicates: number; // skipped because that pubkey was already present
+}
+
+// Splice additional vkey witnesses into a transaction, preserving every other
+// byte exactly (body hash and existing signatures stay valid).
+export function addVkeyWitnesses(txHex: string, toAdd: VkeyWitness[]): AddWitnessResult {
+  const buf = hexToBytes(txHex);
+  const layout = locateTxParts(buf);
+  const wsetBuf = buf.slice(layout.wsetStart, layout.wsetEnd);
+
+  const head = readHead(wsetBuf, 0);
+  if (head.major !== MAJOR_MAP) throw new Error("Witness set is not a CBOR map");
+  if (head.indefinite) throw new Error("Indefinite-length witness set is not supported");
+
+  // Walk the witness-set map, copying every entry's raw bytes. Capture key 0
+  // (vkey witnesses) so we can merge into it.
+  let p = head.headEnd;
+  const otherEntries: Uint8Array[] = []; // raw key+value bytes for keys != 0
+  let existingVkeys: VkeyWitness[] = [];
+  for (let i = 0; i < head.arg; i++) {
+    const entryStart = p;
+    const keyHead = readHead(wsetBuf, p);
+    const valueStart = keyHead.headEnd;
+    const valueEnd = skipItem(wsetBuf, valueStart);
+    if (keyHead.major === MAJOR_UNSIGNED && keyHead.arg === 0) {
+      existingVkeys = readVkeyArray(wsetBuf, valueStart);
+    } else {
+      otherEntries.push(wsetBuf.slice(entryStart, valueEnd));
+    }
+    p = valueEnd;
+  }
+
+  // Merge, deduping by public key.
+  const seen = new Set(existingVkeys.map((w) => bytesToHex(w.vkey)));
+  const merged = [...existingVkeys];
+  let added = 0;
+  let duplicates = 0;
+  for (const w of toAdd) {
+    const k = bytesToHex(w.vkey);
+    if (seen.has(k)) {
+      duplicates += 1;
+      continue;
+    }
+    seen.add(k);
+    merged.push(w);
+    added += 1;
+  }
+
+  // Rebuild key 0's array and the whole witness-set map. Key 0 is the smallest
+  // unsigned key, so it sorts first — emit it, then the untouched entries.
+  const key0Array = concatBytes(encodeHead(MAJOR_ARRAY, merged.length), ...merged.map(encodeVkeyWitness));
+  const key0Entry = concatBytes(encodeHead(MAJOR_UNSIGNED, 0), key0Array);
+  const mapCount = otherEntries.length + (merged.length > 0 ? 1 : 0);
+  const newWsetParts: Uint8Array[] = [encodeHead(MAJOR_MAP, mapCount)];
+  if (merged.length > 0) newWsetParts.push(key0Entry);
+  newWsetParts.push(...otherEntries);
+  const newWset = concatBytes(...newWsetParts);
+
+  // Splice: everything before the witness set + new witness set + everything after.
+  const newTx = concatBytes(buf.slice(0, layout.wsetStart), newWset, buf.slice(layout.wsetEnd));
+  return { txHex: bytesToHex(newTx), added, duplicates };
+}
+
+// ---------------------------------------------------------------------------
+// Hashing & signature verification
+// ---------------------------------------------------------------------------
+
+// blake2b-256 of the transaction body's exact CBOR bytes — the signing hash /
+// transaction id that every vkey witness signs.
+export function txBodyHash(txHex: string): Uint8Array {
+  const buf = hexToBytes(txHex);
+  const layout = locateTxParts(buf);
+  return blake2b(buf.slice(layout.bodyStart, layout.bodyEnd), { dkLen: 32 });
+}
+
+// blake2b-224 of a public key — the key hash used in required_signers and in
+// the validator's `missing_key_hash`.
+export function vkeyHash(vkey: Uint8Array): string {
+  return bytesToHex(blake2b(vkey, { dkLen: 28 }));
+}
+
+export function verifySignature(bodyHash: Uint8Array, w: VkeyWitness): boolean {
+  try {
+    return ed25519.verify(w.signature, bodyHash, w.vkey);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Following on from the submission button, I thought it'd be useful to be able to add a witness to a transaction, instead of having to cardano-cli assemble.

<img width="1216" height="531" alt="image" src="https://github.com/user-attachments/assets/dfb2b9ff-7bec-408c-a436-6b510b38ebab" />

<img width="1214" height="641" alt="image" src="https://github.com/user-attachments/assets/749f574d-2852-42a2-941b-5c354eb0391b" />

<img width="1213" height="660" alt="image" src="https://github.com/user-attachments/assets/fdb6dfcd-bb06-4d23-b0e6-f4e29da6588e" />
